### PR TITLE
Add autoupdate field on plugin update info to force auto update the plugin

### DIFF
--- a/Puc/v4p13/Plugin/Info.php
+++ b/Puc/v4p13/Plugin/Info.php
@@ -35,7 +35,7 @@ if ( !class_exists('Puc_v4p13_Plugin_Info', false) ):
 		public $downloaded;
 		public $active_installs;
 		public $last_updated;
-		public $autoupdate;
+		public $autoupdate = false;
 
 		public $id = 0; //The native WP.org API returns numeric plugin IDs, but they're not used for anything.
 

--- a/Puc/v4p13/Plugin/Info.php
+++ b/Puc/v4p13/Plugin/Info.php
@@ -35,6 +35,7 @@ if ( !class_exists('Puc_v4p13_Plugin_Info', false) ):
 		public $downloaded;
 		public $active_installs;
 		public $last_updated;
+		public $autoupdate;
 
 		public $id = 0; //The native WP.org API returns numeric plugin IDs, but they're not used for anything.
 

--- a/Puc/v4p13/Plugin/Update.php
+++ b/Puc/v4p13/Plugin/Update.php
@@ -17,9 +17,10 @@ if ( !class_exists('Puc_v4p13_Plugin_Update', false) ):
 		public $requires_php = false;
 		public $icons = array();
 		public $filename; //Plugin filename relative to the plugins directory.
+		public $autoupdate;
 
 		protected static $extraFields = array(
-			'id', 'homepage', 'tested', 'requires_php', 'upgrade_notice', 'icons', 'filename',
+			'id', 'homepage', 'tested', 'requires_php', 'upgrade_notice', 'icons', 'filename', 'autoupdate',
 		);
 
 		/**
@@ -83,6 +84,7 @@ if ( !class_exists('Puc_v4p13_Plugin_Update', false) ):
 			$update->tested = $this->tested;
 			$update->requires_php = $this->requires_php;
 			$update->plugin = $this->filename;
+			$update->autoupdate = $this->autoupdate;
 
 			if ( !empty($this->upgrade_notice) ) {
 				$update->upgrade_notice = $this->upgrade_notice;

--- a/Puc/v4p13/Plugin/Update.php
+++ b/Puc/v4p13/Plugin/Update.php
@@ -17,7 +17,7 @@ if ( !class_exists('Puc_v4p13_Plugin_Update', false) ):
 		public $requires_php = false;
 		public $icons = array();
 		public $filename; //Plugin filename relative to the plugins directory.
-		public $autoupdate;
+		public $autoupdate = false;
 
 		protected static $extraFields = array(
 			'id', 'homepage', 'tested', 'requires_php', 'upgrade_notice', 'icons', 'filename', 'autoupdate',


### PR DESCRIPTION
@DavidAnderson684 

I found that in order to force update the plugin, we need to add an `autoupdate` parameter to the plugin update info. If this parameter is present and its value is `true`, then WordPress will force update the plugin when the auto update cron runs.

**How to test this branch**

1. Add the `autoupdate` parameter to the plugin update info and set the value to `true`.

<img width="250" height="178" alt="1" src="https://github.com/user-attachments/assets/4310fe8e-1f58-4637-ace9-ba25649e6170" />

2. Run the `wp_update_plugins ` and `wp_version_check ` cron.

<img width="300" height="99" alt="2" src="https://github.com/user-attachments/assets/a14dc98e-9e72-482a-97f4-a99babf5caa8" />


3. You should see that the plugin was updated automatically.