### PR TITLE
Remove PHP deprecation warnings

### DIFF
--- a/Puc/v4p13/StateStore.php
+++ b/Puc/v4p13/StateStore.php
@@ -76,7 +76,7 @@ if ( !class_exists('Puc_v4p13_StateStore', false) ):
 		 * @param Puc_v4p13_Update|null $update
 		 * @return $this
 		 */
-		public function setUpdate(Puc_v4p13_Update $update = null) {
+		public function setUpdate($update = null) {
 			$this->lazyLoad();
 			$this->update = $update;
 			return $this;

--- a/Puc/v4p13/UpdateChecker.php
+++ b/Puc/v4p13/UpdateChecker.php
@@ -357,7 +357,7 @@ if ( !class_exists('Puc_v4p13_UpdateChecker', false) ):
 		 *
 		 * @param Puc_v4p13_Metadata|null $update
 		 */
-		protected function fixSupportedWordpressVersion(Puc_v4p13_Metadata $update = null) {
+		protected function fixSupportedWordpressVersion($update = null) {
 			if ( !isset($update->tested) || !preg_match('/^\d++\.\d++$/', $update->tested) ) {
 				return;
 			}


### PR DESCRIPTION
@DavidAnderson684 

This PR fixes these deprecation warnings on PHP 8.4:

<img width="1701" height="138" alt="deprecation-warnings" src="https://github.com/user-attachments/assets/ba02eb86-82ed-4a99-91de-c0f3b13b4edc" />


The issue is about [the deprecation of the implicitly nullable parameter declarations](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). Because we still want to support PHP 5, the solution is to drop the parameter type instead.
